### PR TITLE
Update the drlm-cli repo name to drlmctl

### DIFF
--- a/Docs/CONTRIBUTING.rst
+++ b/Docs/CONTRIBUTING.rst
@@ -12,7 +12,7 @@ First of all you need to Fork DRLMv3 repos with your GitHub account.
 Here the required repos you must fork from:
 
    * github.com/brainupdaters/drlm-core
-   * github.com/brainupdaters/drlm-cli
+   * github.com/brainupdaters/drlmctl
    * github.com/brainupdaters/drlm-common
    * github.com/brainupdaters/drlm-agent
 
@@ -28,17 +28,17 @@ Quick start summary (You must have pre-required software in place, see link abov
 
    3. Start the development environment (1st time will take a while, enjoying coffe? ;))
    ``make start-all ghuser=<Github_User> gitname='Name Surname' gitmail='your@email.net'``
-   Only 1st time you run ``make start-all`` all arguments are required to do a proper auto-setup 
-   of git, git-flow, etc. The following times no arguments are required and will be fast.  
+   Only 1st time you run ``make start-all`` all arguments are required to do a proper auto-setup
+   of git, git-flow, etc. The following times no arguments are required and will be fast.
 
-   4. Here you are in a container shell (godev). 
+   4. Here you are in a container shell (godev).
    ``cd go/src/github.com/brainupdaters``
-   Use ``code`` or ``nvim`` to develop, are pre-configured with the required plugins to work with. 
+   Use ``code`` or ``nvim`` to develop, are pre-configured with the required plugins to work with.
 
    5. To stop development session. Exit you container shell after saving your work and run:
    ``make stop-all``
-   Your work is safe in files directory of the repo. While you do not remove the repo folder or run 
-   ``make clean-all`` you will be able to continue developing with saved data from last session ;).  
+   Your work is safe in files directory of the repo. While you do not remove the repo folder or run
+   ``make clean-all`` you will be able to continue developing with saved data from last session ;).
 
    5. Happy coding! ;)
 
@@ -56,7 +56,7 @@ Bug reports are submited through `GitHub Issues <https://guides.github.com/featu
 * Specify which version of DRLM you're using
 * Specify which OS you're using (both the server and the client)
 
- 
+
 F ixing a bug
 ````````````
 If you want to fix a bug, you have to follow this steps:
@@ -69,7 +69,7 @@ If you want to fix a bug, you have to follow this steps:
 
    Read the Contributing instructions above.
 
-   **Note**: Git and GitFlow setup is done automatically if followed the previous `instructions <https://github.com/didacog/dr3dev/blob/master/Docs/CONTRIBUTING.rst#how-can-i-contribute>`_. 
+   **Note**: Git and GitFlow setup is done automatically if followed the previous `instructions <https://github.com/didacog/dr3dev/blob/master/Docs/CONTRIBUTING.rst#how-can-i-contribute>`_.
 
 3. **Create the new branch**
 
@@ -90,13 +90,13 @@ If you want to fix a bug, you have to follow this steps:
 
    After publishing the branch, go to the `Brain Updaters DRLMv3 repositories <https://github.com/brainupdaters>`_ and make a new Pull Request from your ``feature/<feature-name>`` branch of your fork to the ``develop`` branch. Don't worry, we'll change your Pull Request to the correct branch. You might need to click ``compare between forks``.
 
-   **Note**: in case you face merge conficts, you'll need to `Update your fork`_ and resolve the conficts locally. 
+   **Note**: in case you face merge conficts, you'll need to `Update your fork`_ and resolve the conficts locally.
    **Note**: in case you commit changes after executing ``git flow hotfix publish``, you'll need to execute ``git push`` in order to upload your latest changes to the Pull Request
 
 6. **Cleanup**
 
    After the Pull Request is merged, remember to remove the branch in your local repository and in the GitHub.
-   
+
    To delete the local branch, you need to execute:
    ``git checkout develop && git branch -d feature/<feature-name>``
 
@@ -105,16 +105,16 @@ If you want to fix a bug, you have to follow this steps:
    Or do it directly through the command line:
 
    ``git push --delete feature/<feature-name>``
- 
+
 Suggesting new features or enhancements
 ```````````````````````````````````````
 Suggestions are submited through `GitHub Issues <https://guides.github.com/features/issues/>`_.
 
-* Use a clear and descriptive title 
+* Use a clear and descriptive title
 * Explain with detail the feature/enhancements
 * Explain why the feature/enhancements would benefit the DRLM users
 
- 
+
 Adding a new functionality
 ``````````````````````````
 If you want to add new functionality, you have to follow this steps:
@@ -127,7 +127,7 @@ If you want to add new functionality, you have to follow this steps:
 
    Read the Contributing instructions above.
 
-   **Note**: Git and GitFlow setup is done automatically if followed the `instructions <https://github.com/didacog/dr3dev/blob/master/Docs/CONTRIBUTING.rst#how-can-i-contribute>`_. 
+   **Note**: Git and GitFlow setup is done automatically if followed the `instructions <https://github.com/didacog/dr3dev/blob/master/Docs/CONTRIBUTING.rst#how-can-i-contribute>`_.
 
 4. **Create the new branch**
 
@@ -154,7 +154,7 @@ If you want to add new functionality, you have to follow this steps:
 7. **Cleanup**
 
    After the Pull Request is merged, remember to remove the branch in your local repository and in the GitHub.
-   
+
    To delete the local branch, you need to execute:
    ``git checkout develop && git branch -d feature/<feature-name>``
 
@@ -164,20 +164,20 @@ If you want to add new functionality, you have to follow this steps:
 
    ``git push --delete feature/<feature-name>``
 
-  
+
 Style guidelines
 ----------------
 
 Git Flow
 ````````
-DRLM follows a `Git Flow <https://danielkummer.github.io/git-flow-cheatsheet>`_ workflow. 
+DRLM follows a `Git Flow <https://danielkummer.github.io/git-flow-cheatsheet>`_ workflow.
 
- 
+
 Semantic Versioning
 ```````````````````
 DRLM uses `Semantic Versioning <https://semver.org>`_
 
- 
+
 Other
 -----
 

--- a/docker/godev/entrypoint.sh
+++ b/docker/godev/entrypoint.sh
@@ -7,23 +7,23 @@ set -e
 if [ ! -x /usr/local/go/bin/go ]; then
 	# Install Golang
 	GOLANG_VERSION=1.11.5
-	ARCH=amd64 
+	ARCH=amd64
 	url="https://golang.org/dl/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz"
 
 	echo "#####################"
-	echo "######## Installing Golang ${GOLANG_VERSION} ..." 
+	echo "######## Installing Golang ${GOLANG_VERSION} ..."
 	echo "#####################"
 
 	#set -eux
-	curl -fLo go.tgz "$url" 
+	curl -fLo go.tgz "$url"
 	#echo "${goRelSha256} *go.tgz" | sha256sum -c - && \
-	sudo tar -C /usr/local -xzf go.tgz 
+	sudo tar -C /usr/local -xzf go.tgz
 	rm go.tgz
 	export PATH="/usr/local/go/bin:$PATH"
 
 else
 	echo "#####################"
-	echo "######## Skipping ... Go already installed!! ;)" 
+	echo "######## Skipping ... Go already installed!! ;)"
 	echo "#####################"
 fi
 
@@ -34,16 +34,16 @@ if [ ! -x /usr/local/protoc/bin/protoc ]; then
 	url="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-${ARCH}.zip"
 
 	echo "#####################"
-	echo "Installing Protocol buffers ${PROTO_VERSION} ..." 
+	echo "Installing Protocol buffers ${PROTO_VERSION} ..."
 	echo "#####################"
 
-	curl -fLo proto.zip "$url" 
+	curl -fLo proto.zip "$url"
 	sudo unzip -d /usr/local/protoc proto.zip
 	rm proto.zip
 	export PATH="/usr/local/protoc/bin:$PATH"
 else
 	echo "#####################"
-	echo "######## Skipping ... Protobuffers already installed!! ;)" 
+	echo "######## Skipping ... Protobuffers already installed!! ;)"
 	echo "#####################"
 fi
 
@@ -66,8 +66,8 @@ else
 fi
 
 [ -f "$HOME"/dots/bash/bashrc ] && ln -sf ${HOME}/dots/bash/bashrc ${HOME}/.bashrc
-[ -f "$HOME"/dots/bash/bash_profile ] &&  ln -sf ${HOME}/dots/bash/bash_profile ${HOME}/.bash_profile; 
-[ -f "$HOME"/dots/bash/inputrc ] &&  ln -sf ${HOME}/dots/bash/inputrc ${HOME}/.inputrc; 
+[ -f "$HOME"/dots/bash/bash_profile ] &&  ln -sf ${HOME}/dots/bash/bash_profile ${HOME}/.bash_profile;
+[ -f "$HOME"/dots/bash/inputrc ] &&  ln -sf ${HOME}/dots/bash/inputrc ${HOME}/.inputrc;
 [ -d "$HOME"/dots/bash ] && ln -sf ${HOME}/dots/bash ${HOME}/.bash
 [ -f "$HOME"/dots/code/settings.json ] && mkdir -p "${HOME}/.config/Code - OSS/User" && ln -sf ${HOME}/dots/code/settings.json "${HOME}/.config/Code - OSS/User/settings.json"
 
@@ -81,9 +81,9 @@ if [ ! -d "$HOME"/.vim/plugged/vim-go ]; then
 	echo "#####################"
 # Install Vim Plugins + vim-go binaries
 #curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
-	nvim --headless +qa 
-	nvim --headless +PlugInstall +qa 
-	nvim --headless "+CocInstall coc-json" +qa 
+	nvim --headless +qa
+	nvim --headless +PlugInstall +qa
+	nvim --headless "+CocInstall coc-json" +qa
 	nvim --headless +GoInstallBinaries +qa
 else
 	echo "#####################"
@@ -128,7 +128,7 @@ echo "#####################"
 #go get -v github.com/golang/protobuf/protoc-gen-go
 ## drlm upstream libs
 #go get -v -u github.com/brainupdaters/drlm-core
-#go get -v -u github.com/brainupdaters/drlm-cli
+#go get -v -u github.com/brainupdaters/drlmctl
 #go get -v -u github.com/brainupdaters/drlm-common
 #go get -v -u github.com/brainupdaters/drlm-agent
 
@@ -152,15 +152,15 @@ if [ -f ${HOME}/go/dr3env.ghuser ]; then
 # 	workdir="${HOME}/go/src/github.com/${user}"
 	workdir="${HOME}/go/src/github.com/brainupdaters"
 	mkdir -vp ${workdir}
-	for repo in common cli agent core
+	for repo in drlm-common drlmctl drlm-agent drlm-core
 	do
-		if [ ! -d ${workdir}/drlm-${repo}/.git ]; then
-			git clone https://github.com/brainupdaters/drlm-${repo} ${workdir}/drlm-${repo} && \
-				cd ${workdir}/drlm-${repo} && \
+		if [ ! -d ${workdir}/${repo}/.git ]; then
+			git clone https://github.com/brainupdaters/${repo} ${workdir}/${repo} && \
+				cd ${workdir}/${repo} && \
 				git config url."https://${user}@github.com".InsteadOf "https://github.com" && \
 				git checkout -b master && \
 				git checkout develop && \
-				git remote add fork https://github.com/${user}/drlm-${repo} && \
+				git remote add fork https://github.com/${user}/${repo} && \
 				git remote rename origin upstream && \
 				git remote rename fork origin && \
 				git fetch upstream && \
@@ -168,7 +168,7 @@ if [ -f ${HOME}/go/dr3env.ghuser ]; then
 				GO111MODULE=on go mod tidy && \
 				cd
 		else
-			cd ${workdir}/drlm-${repo} && \
+			cd ${workdir}/${repo} && \
 				git fetch upstream && \
 				GO111MODULE=on go mod tidy && \
 				cd

--- a/docker/godev/nvim/entrypoint.sh
+++ b/docker/godev/nvim/entrypoint.sh
@@ -7,20 +7,20 @@ set -e
 if [ ! -x /usr/local/go/bin/go ]; then
 	# Install Golang
 	GOLANG_VERSION=1.11.5
-	ARCH=amd64 
+	ARCH=amd64
 	url="https://golang.org/dl/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz"
 
-	echo "Installing Golang ${GOLANG_VERSION} ..." 
+	echo "Installing Golang ${GOLANG_VERSION} ..."
 
 	#set -eux
-	curl -fLo go.tgz "$url" 
+	curl -fLo go.tgz "$url"
 	#echo "${goRelSha256} *go.tgz" | sha256sum -c - && \
-	sudo tar -C /usr/local -xzf go.tgz 
+	sudo tar -C /usr/local -xzf go.tgz
 	rm go.tgz
 	export PATH="/usr/local/go/bin:$PATH"
 
 else
-	echo "Skipping ... Go already installed!! ;)" 
+	echo "Skipping ... Go already installed!! ;)"
 fi
 
 if [ ! -x /usr/local/protoc/bin/protoc ]; then
@@ -29,13 +29,13 @@ if [ ! -x /usr/local/protoc/bin/protoc ]; then
 	ARCH=x86_64
 	url="https://github.com/protocolbuffers/protobuf/releases/download/v${PROTO_VERSION}/protoc-${PROTO_VERSION}-linux-${ARCH}.zip"
 
-	echo "Installing Protocol buffers ${PROTO_VERSION} ..." 
-	curl -fLo proto.zip "$url" 
+	echo "Installing Protocol buffers ${PROTO_VERSION} ..."
+	curl -fLo proto.zip "$url"
 	sudo unzip -d /usr/local/protoc proto.zip
 	rm proto.zip
 	export PATH="/usr/local/protoc/bin:$PATH"
 else
-	echo "Skipping ... Protobuffers already installed!! ;)" 
+	echo "Skipping ... Protobuffers already installed!! ;)"
 fi
 
 if [ -f "$HOME"/dots/custom/init.vim ]; then
@@ -51,8 +51,8 @@ else
 fi
 
 [ -f "$HOME"/dots/bash/bashrc ] && ln -sf ${HOME}/dots/bash/bashrc ${HOME}/.bashrc
-[ -f "$HOME"/dots/bash/bash_profile ] &&  ln -sf ${HOME}/dots/bash/bash_profile ${HOME}/.bash_profile; 
-[ -f "$HOME"/dots/bash/inputrc ] &&  ln -sf ${HOME}/dots/bash/inputrc ${HOME}/.inputrc; 
+[ -f "$HOME"/dots/bash/bash_profile ] &&  ln -sf ${HOME}/dots/bash/bash_profile ${HOME}/.bash_profile;
+[ -f "$HOME"/dots/bash/inputrc ] &&  ln -sf ${HOME}/dots/bash/inputrc ${HOME}/.inputrc;
 [ -d "$HOME"/dots/bash ] && ln -sf ${HOME}/dots/bash ${HOME}/.bash
 
 touch ${HOME}/.bash_history
@@ -61,9 +61,9 @@ touch ${HOME}/.bash_history
 
 # Install Vim Plugins + vim-go binaries
 #curl -fLo ~/.local/share/nvim/site/autoload/plug.vim --create-dirs "https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim"
-nvim --headless +qall 
-nvim --headless +PlugInstall +qall 
-nvim --headless +PlugInstall +UpdateRemotePlugins +qall 
+nvim --headless +qall
+nvim --headless +PlugInstall +qall
+nvim --headless +PlugInstall +UpdateRemotePlugins +qall
 nvim --headless +GoInstallBinaries +qall
 
 go get -u github.com/sourcegraph/go-langserver
@@ -73,7 +73,7 @@ go get -u github.com/Sirupsen/logrus
 go get -u github.com/golang/protobuf/protoc-gen-go
 
 go get -u github.com/brainupdaters/drlm-core
-go get -u github.com/brainupdaters/drlm-cli
+go get -u github.com/brainupdaters/drlmctl
 go get -u github.com/brainupdaters/drlm-common/comms
 go get -u github.com/brainupdaters/drlm-common/logger
 go get -u github.com/brainupdaters/drlm-agent

--- a/docker/godev/vscode/entrypoint.sh
+++ b/docker/godev/vscode/entrypoint.sh
@@ -4,17 +4,17 @@ set -e
 if [ ! -x /usr/local/go/bin/go ]; then
 	# Install Golang
 	GOLANG_VERSION=1.11.5
-	ARCH=amd64 
+	ARCH=amd64
 	url="https://golang.org/dl/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz"
 
 	echo "Installing Golang version ${GOLANG_VERSION} ..."
 
-	curl -fLo go.tgz "$url" 
-	sudo tar -C /usr/local -xzf go.tgz 
+	curl -fLo go.tgz "$url"
+	sudo tar -C /usr/local -xzf go.tgz
 	rm go.tgz
 	export PATH="/usr/local/go/bin:$PATH"
 else
-	echo "Skipping ... Go already installed!! ;)" 
+	echo "Skipping ... Go already installed!! ;)"
 fi
 
 if [ ! -x /usr/local/protoc/bin/protoc ]; then
@@ -40,7 +40,7 @@ else
 fi
 
 [ -f "$HOME"/dots/bash/bashrc ] && ln -sf ${HOME}/dots/bash/bashrc ${HOME}/.bashrc
-[ -f "$HOME"/dots/bash/bash_profile ] &&  ln -sf ${HOME}/dots/bash/bash_profile ${HOME}/.bash_profile; 
+[ -f "$HOME"/dots/bash/bash_profile ] &&  ln -sf ${HOME}/dots/bash/bash_profile ${HOME}/.bash_profile;
 [ -f "$HOME"/dots/bash/inputrc ] &&  ln -sf ${HOME}/dots/bash/inputrc ${HOME}/.inputrc;
 [ -d "$HOME"/dots/bash ] && ln -sf ${HOME}/dots/bash ${HOME}/.bash;
 [ -f "$HOME"/dots/code/settings.json ] && mkdir -p "${HOME}/.config/Code - OSS/User" && ln -sf ${HOME}/dots/code/settings.json "${HOME}/.config/Code - OSS/User/settings.json"
@@ -61,7 +61,7 @@ go get -u github.com/Sirupsen/logrus
 go get -u github.com/golang/protobuf/protoc-gen-go
 
 go get -u github.com/brainupdaters/drlm-core
-go get -u github.com/brainupdaters/drlm-cli
+go get -u github.com/brainupdaters/drlmctl
 go get -u github.com/brainupdaters/drlm-common/comms
 go get -u github.com/brainupdaters/drlm-common/logger
 go get -u github.com/brainupdaters/drlm-agent
@@ -73,7 +73,7 @@ if [[ -f ${HOME}/go/dr3env.gitname && -f ${HOME}/go/dr3env.gitmail ]]; then
 	echo "name = ${name}" >> ${HOME}/.gitconfig
 	echo "email = ${mail}" >> ${HOME}/.gitconfig
 else
-	echo "Missing ${HOME}/.gitconfig information! gitname & gitmail not provided!" 
+	echo "Missing ${HOME}/.gitconfig information! gitname & gitmail not provided!"
 fi
 
 if [ -f ${HOME}/go/dr3env.ghuser ]; then
@@ -99,7 +99,7 @@ if [ -f ${HOME}/go/dr3env.ghuser ]; then
 		fi
 	done
 else
-	echo "Missing github user information! ghuser not provided! no repo autoconfig will be done!" 
+	echo "Missing github user information! ghuser not provided! no repo autoconfig will be done!"
 fi
 
 exec "$@"


### PR DESCRIPTION
Since the `drlm-cli` tool is now called `drlmctl` and the repo has been renamed, it needs to be renamed here too.